### PR TITLE
Owner can change their private lists to public

### DIFF
--- a/codedigger/lists/fixtures/list_info.json
+++ b/codedigger/lists/fixtures/list_info.json
@@ -94,5 +94,13 @@
 			"p_list": 2,
 			"problem": 6
 		}
+	},
+	{
+		"model": "lists.listinfo",
+		"pk": 13,
+		"fields": {
+			"p_list": 3,
+			"problem": 1
+		}
 	}
 ]

--- a/codedigger/lists/fixtures/lists.json
+++ b/codedigger/lists/fixtures/lists.json
@@ -24,5 +24,18 @@
 			"public": true,
 			"slug": "testinglist_levelwise"
 		}
+	},
+	{
+		"model": "lists.list",
+		"pk": 3,
+		"fields": {
+			"name": "testinglist_userlist",
+			"owner": 1,
+			"isAdmin": false,
+			"isTopicWise": true,
+			"type_list": "3",
+			"public": false,
+			"slug": "testinglist_userlist"
+		}
 	}
 ]

--- a/codedigger/lists/fixtures/profiles.json
+++ b/codedigger/lists/fixtures/profiles.json
@@ -12,5 +12,14 @@
 			"spoj": "aaradhya777",
 			"uva_id": "1143870"
 		}
+	},
+	{
+		"model": "user.profile",
+		"pk": 2,
+		"fields": {
+			"owner": 2,
+			"name": "testinguser",
+			"codeforces": "shivam1012"
+		}
 	}
 ]

--- a/codedigger/lists/fixtures/user.json
+++ b/codedigger/lists/fixtures/user.json
@@ -13,5 +13,20 @@
 			"created_at": "2021-10-1T10:00:00.511Z",
 			"updated_at": "2021-10-1T10:00:00.511Z"
 		}
+	},
+	{
+		"model": "user.user",
+		"pk": 2,
+		"fields": {
+			"username": "testinguser",
+			"email": "testinguser@gmail.com",
+			"password": "QWERTY@123",
+			"is_verified": true,
+			"is_active": true,
+			"is_staff": false,
+			"auth_provider": "email",
+			"created_at": "2021-10-1T10:00:00.511Z",
+			"updated_at": "2021-10-1T10:00:00.511Z"
+		}
 	}
 ]

--- a/codedigger/lists/tests/test_lists.py
+++ b/codedigger/lists/tests/test_lists.py
@@ -1,0 +1,74 @@
+from .test_setup import TestSetUp
+from user.models import User, Profile
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+class TestViews(TestSetUp):
+
+    def test_check_owner_can_change_visibility_view(self):
+        slug = "testinglist_userlist"
+        test_url = reverse('userlist-edit',kwargs = {'slug' : slug})
+        here = User.objects.get(username="testing")
+        here.set_password(self.user_data['password'])
+        here.save()
+        res = self.client.post(self.login_url, self.user_data, format="json")
+        token = res.data['tokens']['access']
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        res = client.put(test_url,{'public' : True}, format="json")
+        user = User.objects.get(username="testinguser")
+        user.set_password(self.user_data['password'])
+        user.save()
+        res2 = self.client.post(self.login_url, {'username' : 'testinguser','password' : self.user_data['password']}, format="json")
+        token2 = res2.data['tokens']['access']
+        client2 = APIClient()
+        client2.credentials(HTTP_AUTHORIZATION='Bearer ' + token2)
+        res2 = client2.put(test_url,{'public' : True},format="json")
+        self.assertEqual(res.status_code, 200) and self.assertEqual(res2.status_code, 400)
+    
+    def test_check_restrict_change_visibility_view(self):
+        slug = "testinglist_userlist"
+        test_url = reverse('userlist-edit',kwargs = {'slug' : slug})
+        here = User.objects.get(username="testing")
+        here.set_password(self.user_data['password'])
+        here.save()
+        res = self.client.post(self.login_url, self.user_data, format="json")
+        token = res.data['tokens']['access']
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        res = client.put(test_url,{'public' : True}, format="json")
+        res2 = client.put(test_url,{'public' : False},format="json")
+        self.assertEqual(res.status_code, 200) and self.assertEqual(res2.status_code, 400)
+        
+    # def test_check_only_owner_can_add_problems_view(self):
+    #     test_url = reverse('userlist-add')
+    #     here = User.objects.get(username="testing")
+    #     here.set_password(self.user_data['password'])
+    #     here.save()
+    #     res = self.client.post(self.login_url, self.user_data, format="json")
+    #     token = res.data['tokens']['access']
+    #     client = APIClient()
+    #     client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+    #     data1 = {
+    #         'prob_id' : "4A",
+    #         'slug' : 'testinglist_userlist',
+    #         'platform' : 'F'
+    #     }
+    #     res = client.post(test_url,data1, format="json")
+    #     user = User.objects.get(username="testinguser")
+    #     user.set_password(self.user_data['password'])
+    #     user.save()
+    #     res2 = self.client.post(self.login_url, {'username' : 'testinguser','password' : self.user_data['password']}, format="json")
+    #     token2 = res2.data['tokens']['access']
+    #     client2 = APIClient()
+    #     client2.credentials(HTTP_AUTHORIZATION='Bearer ' + token2)
+    #     data2 = {
+    #         'prob_id' : "abc186_a",
+    #         'slug' : 'testinglist_userlist',
+    #         'platform' : 'A'
+    #     }
+    #     res2 = client2.post(test_url,data2,format="json")
+    #     self.assertEqual(res.status_code, 200) and self.assertEqual(res2.status_code, 400)
+    
+

--- a/codedigger/lists/views.py
+++ b/codedigger/lists/views.py
@@ -502,6 +502,10 @@ class EditUserlistView(generics.GenericAPIView):
                 raise ValidationException(
                     "public field can only be true or false (with the lowercase initial character)"
                 )
+            if curr_list.public == True and public == False:
+                raise ValidationException(
+                    "A list once made public cannot be made private again"
+                )
             curr_list.public = public
         if data.get('delete_probs', None):
             for ele in data.get('delete_probs', None):

--- a/codedigger/lists/views.py
+++ b/codedigger/lists/views.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from user.permissions import *
 from user.exception import *
 from .utils import *
-
+from user.models import User
 
 class TopicwiseGetListView(generics.ListAPIView):
     serializer_class = GetSerializer
@@ -405,6 +405,7 @@ class UserlistAddProblemView(generics.CreateAPIView):
 
     def post(self, request, *args, **kwargs):
         data = request.data
+        here = self.request.user
         prob_id = data.get('prob_id', None)
         slug = data.get('slug', None)
         platform = data.get('platform', None)
@@ -424,6 +425,10 @@ class UserlistAddProblemView(generics.CreateAPIView):
                                     platform=platform).exists():
             raise ValidationException(
                 "Problem with the given prob_id and platform already exists within the list"
+            )
+        if curr_list.owner != here:
+            raise ValidationException(
+                "Only the owner of the list can add problems to this list"
             )
         curr_list.problem.add(curr_prob)
         return response.Response(


### PR DESCRIPTION
I have added a block where if the list is already public and the user wants it to be private, that would raise an error.
In accordance with the points in the issue:
1) Owner can change the public setting of his/her list from an already existing endpoint.
2) Restricts owners to change public list to private.
3) Only owner can edit the list ( this feature was already present).