### PR TITLE
Added user-list route resolve #38

### DIFF
--- a/codedigger/lists/serializers.py
+++ b/codedigger/lists/serializers.py
@@ -208,13 +208,6 @@ class UpdateListSerializer(serializers.Serializer):
             'page',
         )
 
-
-class GetListSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = List
-        fields = ('id', 'name', 'description', 'slug', 'public')
-
-
 class AddProblemsAdminSerializer(serializers.Serializer):
     slug = serializers.SlugField(required=True)
 

--- a/codedigger/lists/tests/test_lists.py
+++ b/codedigger/lists/tests/test_lists.py
@@ -1,4 +1,6 @@
 from django.test import client
+
+from user.exception import ValidationException
 from .test_setup import TestSetUp
 from user.models import User, Profile
 from django.urls import reverse
@@ -84,7 +86,7 @@ class TestViews(TestSetUp):
 
     def test_get_user_list(self):
         username = "testing"
-        test_url = reverse('user-list') + username
+        test_url = reverse('user-list',kwargs={'username': username})
         here = User.objects.get(username="testing")
         here.set_password(self.user_data['password'])
         here.save()
@@ -93,4 +95,13 @@ class TestViews(TestSetUp):
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
         res = client.get(test_url, format="json")
-        self.assertEqual(res.status_code, 200)
+        
+        username2 = "testing1"
+        test_url = reverse('user-list',kwargs={'username': username2})
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        res2 = client.get(test_url, format="json")
+
+        self.assertEqual(res.status_code, 200) and self.assertRaises(ValidationException, res2)
+        if(len(res.data['result'])>0):
+            self.assertEqual(res.data['result'][0]['public'],True)

--- a/codedigger/lists/views.py
+++ b/codedigger/lists/views.py
@@ -4,8 +4,7 @@ from problem.models import Problem
 from .serializers import (GetLadderSerializer, GetSerializer,
                           GetUserlistSerializer, EditUserlistSerializer,
                           CreateUserlistSerializer, ProblemSerializer,
-                          UserlistAddSerializer, AddProblemsAdminSerializer,
-                          GetListSerializer)
+                          UserlistAddSerializer, AddProblemsAdminSerializer,)
 from django.db.models import Q
 from user.permissions import *
 from user.exception import *
@@ -403,8 +402,21 @@ class ListGetView(generics.ListAPIView):
             qs = List.objects.filter(owner=self.request.user)
         else:
             qs = List.objects.filter(Q(owner=user) & Q(public=True))
-
         return qs
+    
+    def get(self,request,username):
+        qs = self.get_queryset()
+        send_data = []
+        for q in qs:
+            dt = {
+                "id":q.id,
+                "name": q.name,
+                "description": q.description,
+                "slug": q.slug,
+                "public": q.public
+            }
+            send_data.append(dt)
+        return response.Response({'status':'OK','result':send_data})
 
 
 class UserlistCreateView(generics.CreateAPIView):

--- a/codedigger/lists/views.py
+++ b/codedigger/lists/views.py
@@ -406,16 +406,7 @@ class ListGetView(generics.ListAPIView):
     
     def get(self,request,username):
         qs = self.get_queryset()
-        send_data = []
-        for q in qs:
-            dt = {
-                "id":q.id,
-                "name": q.name,
-                "description": q.description,
-                "slug": q.slug,
-                "public": q.public
-            }
-            send_data.append(dt)
+        send_data = GetUserlistSerializer(qs, many=True).data
         return response.Response({'status':'OK','result':send_data})
 
 


### PR DESCRIPTION
# Added a route to get all lists of user

## Description

This route will get all the public problems of the user's list if the user is authorized user then he will get his both public and private list
Fixes #38 

- [x] New feature (non-breaking change which adds functionality)

Route -
`/lists/user/:username`


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
